### PR TITLE
Support full swagger generation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.0.7
-elixir 1.9.0
+erlang 23.3
+elixir 1.11.4

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,10 +29,12 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
-if Mix.env() == :test do
-  config :kazan,
-    oai_name_mappings: [{"something.test", Kazan.Something}]
-end
+config :kazan,
+  oai_spec: "kube_specs/k8s-swagger.json",
+  oai_name_mappings: [
+    {"io.cert-manager.", Kazan.Crds.CertManager}
+  ]
+
 
 if Mix.env() == :dev do
   config :kazan,

--- a/lib/kazan/codegen/models.ex
+++ b/lib/kazan/codegen/models.ex
@@ -143,7 +143,7 @@ defmodule Kazan.Codegen.Models do
     {:boolean, [], Elixir}
   end
 
-  defp typespec_for_property(%PropertyDesc{type: :object}) do
+  defp typespec_for_property(%PropertyDesc{type: _}) do
     {:map, [], Elixir}
   end
 
@@ -192,6 +192,8 @@ defmodule Kazan.Codegen.Models do
 
         :boolean ->
           "`Boolean`"
+
+        nil -> "`Map`"
       end
     end
   end

--- a/lib/kazan/codegen/naming.ex
+++ b/lib/kazan/codegen/naming.ex
@@ -77,15 +77,28 @@ defmodule Kazan.Codegen.Naming do
           String.starts_with?(other, oai_prefix)
         end)
         |> case do
-          nil ->
-            raise Kazan.UnknownName, name: other
-
           {oai_prefix, module_prefix} ->
             [module_prefix] ++
               to_components.(String.replace_leading(other, oai_prefix, ""))
+          nil ->
+            [Kazan.Crds] ++ to_components.(reverse_dots(other))
         end
     end
   end
+
+  defp reverse_dots(oai_name) do
+    String.split(oai_name, ".")
+    |> Enum.reverse()
+    |> prune_package_prefix()
+    |> case do
+      [resource, vsn | rest] -> rest ++ [vsn, resource]
+      pass -> pass
+    end
+    |> Enum.join(".")
+  end
+
+  defp prune_package_prefix([_, "Apis", "Pkg" | rest]), do: rest
+  defp prune_package_prefix(pass), do: pass
 
   # Uppercases the first character of str
   # This is different from capitalize, in that it leaves the rest of the string

--- a/test/apis_test.exs
+++ b/test/apis_test.exs
@@ -2,7 +2,7 @@ defmodule KazanApiTests do
   use ExUnit.Case
 
   alias Kazan.Apis.Core.V1, as: CoreV1
-  alias Kazan.Apis.Extensions.V1beta1, as: ExtensionsV1beta1
+  alias Kazan.Apis.Networking
   alias Kazan.Models.Apimachinery.Meta.V1.ObjectMeta
 
   describe "Apis.oai_id_to_functions" do
@@ -38,7 +38,7 @@ defmodule KazanApiTests do
 
   test "request with path params" do
     {:ok, res} =
-      ExtensionsV1beta1.read_namespaced_network_policy(
+      Networking.V1.read_namespaced_network_policy(
         "test-namespace",
         "test-policy",
         pretty: true
@@ -48,7 +48,7 @@ defmodule KazanApiTests do
     assert res.method == "get"
 
     assert res.path ==
-             "/apis/extensions/v1beta1/namespaces/test-namespace/networkpolicies/test-policy"
+             "/apis/networking.k8s.io/v1/namespaces/test-namespace/networkpolicies/test-policy"
 
     assert res.query_params == %{"pretty" => true}
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -2,8 +2,8 @@ defmodule KazanIntegrationTest do
   use ExUnit.Case, async: false
 
   alias Kazan.Apis.Core.V1, as: CoreV1
-  alias Kazan.Apis.Extensions.V1beta1, as: ExtensionsV1beta1
-  alias Kazan.Apis.Rbacauthorization.V1beta1, as: RbacauthorizationV1beta1
+  alias Kazan.Apis.Apps.V1, as: AppsV1
+  alias Kazan.Apis.Rbacauthorization.V1, as: RbacauthorizationV1
   alias Kazan.Apis.Core.V1.{Pod, PodStatus, PodSpec, Container}
 
   alias Kazan.Models.Apimachinery.Meta.V1.{
@@ -56,7 +56,7 @@ defmodule KazanIntegrationTest do
   end
 
   test "can list deployments on an actual server", %{server: server} do
-    ExtensionsV1beta1.list_namespaced_deployment!(@namespace)
+    AppsV1.list_namespaced_deployment!(@namespace)
     |> Kazan.run!(server: server)
   end
 
@@ -87,7 +87,7 @@ defmodule KazanIntegrationTest do
 
   test "RBAC Authorization V1 Beta 1 API", %{server: server} do
     cluster_roles =
-      RbacauthorizationV1beta1.list_cluster_role!()
+      RbacauthorizationV1.list_cluster_role!()
       |> Kazan.run!(server: server)
 
     assert cluster_roles.kind == "ClusterRoleList"
@@ -195,12 +195,13 @@ defmodule KazanIntegrationTest do
   end
 
   describe "Custom Resources" do
-    alias Kazan.Apis.Apiextensions.V1beta1, as: Apiextensions
+    alias Kazan.Apis.Apiextensions.V1, as: Apiextensions
 
     alias Apiextensions.{
       CustomResourceDefinition,
       CustomResourceDefinitionSpec,
-      CustomResourceDefinitionNames
+      CustomResourceDefinitionNames,
+      CustomResourceDefinitionVersion
     }
 
     setup %{server: server} do
@@ -209,7 +210,7 @@ defmodule KazanIntegrationTest do
           metadata: %ObjectMeta{name: "foos.example.com"},
           spec: %CustomResourceDefinitionSpec{
             group: "example.com",
-            version: "v1",
+            versions: [%CustomResourceDefinitionVersion{name: "v1"}],
             scope: "Namespaced",
             names: %CustomResourceDefinitionNames{
               plural: "foos",

--- a/test/models_test.exs
+++ b/test/models_test.exs
@@ -4,7 +4,8 @@ defmodule KazanModelsTest do
   alias Kazan.Models
   alias Kazan.Apis.Rbac
   alias Kazan.Apis.Core
-  alias Kazan.Apis.Extensions
+  alias Kazan.Apis.Apps
+  alias Kazan.Apis.Autoscaling
 
   test "that we have some models" do
     # Not a particularly thorough test, but whatever:
@@ -41,12 +42,12 @@ defmodule KazanModelsTest do
       {:ok, result} =
         Models.decode(%{
           "kind" => "Scale",
-          "apiVersion" => "extensions/v1beta1"
+          "apiVersion" => "autoscaling/v1"
         })
 
-      assert result == %Extensions.V1beta1.Scale{
+      assert result == %Autoscaling.V1.Scale{
                kind: "Scale",
-               api_version: "extensions/v1beta1"
+               api_version: "autoscaling/v1"
              }
     end
 
@@ -54,13 +55,13 @@ defmodule KazanModelsTest do
       {:ok, result} =
         Models.decode(%{
           "kind" => "ClusterRoleBinding",
-          "apiVersion" => "rbac.authorization.k8s.io/v1beta1",
+          "apiVersion" => "rbac.authorization.k8s.io/v1",
           "subjects" => []
         })
 
-      assert result == %Rbac.V1beta1.ClusterRoleBinding{
+      assert result == %Rbac.V1.ClusterRoleBinding{
                kind: "ClusterRoleBinding",
-               api_version: "rbac.authorization.k8s.io/v1beta1",
+               api_version: "rbac.authorization.k8s.io/v1",
                subjects: []
              }
     end
@@ -78,13 +79,13 @@ defmodule KazanModelsTest do
               "updatedReplicas" => 0
             }
           },
-          Extensions.V1beta1.Deployment
+          Apps.V1.Deployment
         )
 
-      assert result == %Extensions.V1beta1.Deployment{
+      assert result == %Apps.V1.Deployment{
                metadata: nil,
                spec: nil,
-               status: %Extensions.V1beta1.DeploymentStatus{
+               status: %Apps.V1.DeploymentStatus{
                  available_replicas: 1,
                  conditions: [],
                  observed_generation: 1,
@@ -104,13 +105,13 @@ defmodule KazanModelsTest do
               %{"status" => nil}
             ]
           },
-          Extensions.V1beta1.DeploymentList
+          Apps.V1.DeploymentList
         )
 
-      assert result == %Extensions.V1beta1.DeploymentList{
+      assert result == %Apps.V1.DeploymentList{
                items: [
-                 %Extensions.V1beta1.Deployment{},
-                 %Extensions.V1beta1.Deployment{}
+                 %Apps.V1.Deployment{},
+                 %Apps.V1.Deployment{}
                ],
                metadata: nil
              }
@@ -140,10 +141,10 @@ defmodule KazanModelsTest do
 
     test "that we can encode nested models" do
       {:ok, result} =
-        Models.encode(%Extensions.V1beta1.Deployment{
+        Models.encode(%Apps.V1.Deployment{
           metadata: nil,
           spec: nil,
-          status: %Extensions.V1beta1.DeploymentStatus{
+          status: %Apps.V1.DeploymentStatus{
             available_replicas: 1,
             conditions: [],
             observed_generation: 1,
@@ -167,9 +168,9 @@ defmodule KazanModelsTest do
 
     test "that we can encode arrays" do
       {:ok, result} =
-        Models.encode(%Extensions.V1beta1.DeploymentList{
+        Models.encode(%Apps.V1.DeploymentList{
           items: [
-            %Extensions.V1beta1.Deployment{}
+            %Apps.V1.Deployment{}
           ],
           metadata: nil
         })
@@ -214,8 +215,8 @@ defmodule KazanModelsTest do
 
     test "it supports names provided in app config" do
       # Our config.exs defines this mapping, lets see if it works...
-      assert Kazan.Models.oai_name_to_module("something.test.whatever") ==
-               Kazan.Something.Whatever
+      assert Kazan.Models.oai_name_to_module("io.cert-manager.v1.Certificate") ==
+               Kazan.Crds.CertManager.V1.Certificate
     end
   end
 end


### PR DESCRIPTION
Provides a mechanism to ingest a full swagger doc irregardless of crds inside.  Also updates test for later k8s versions.